### PR TITLE
feat: Make layer envelope dimensions configurable

### DIFF
--- a/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoDetector.hpp
+++ b/Examples/Detectors/TGeoDetector/include/ActsExamples/TGeoDetector/TGeoDetector.hpp
@@ -54,6 +54,8 @@ struct TGeoDetector {
     double beamPipeRadius{0};
     double beamPipeHalflengthZ{0};
     double beamPipeLayerThickness{0};
+    double beampipeEnvelopeR{1.0};
+    double layerEnvelopeR{1.0};
 
     double unitScalor = 1.0;
 

--- a/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
+++ b/Examples/Detectors/TGeoDetector/src/TGeoDetector.cpp
@@ -82,6 +82,7 @@ std::vector<Acts::TGeoLayerBuilder::Config> makeLayerBuilderConfigs(
       lConfig.volumeName = volume.subVolumeName.at(ncp);
       lConfig.sensorNames = volume.sensitiveNames.at(ncp);
       lConfig.localAxes = volume.sensitiveAxes.at(ncp);
+      lConfig.envelope = {config.layerEnvelopeR, config.layerEnvelopeR};
 
       auto rR = volume.rRange.at(ncp);
       auto rMin = rR.lower.value_or(0.);
@@ -199,8 +200,8 @@ std::shared_ptr<const Acts::TrackingGeometry> buildTGeoDetector(
     bpvConfig.trackingVolumeHelper = cylinderVolumeHelper;
     bpvConfig.volumeName = "BeamPipe";
     bpvConfig.layerBuilder = beamPipeBuilder;
-    bpvConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
-                                1. * Acts::UnitConstants::mm};
+    bpvConfig.layerEnvelopeR = {config.beampipeEnvelopeR,
+                                config.beampipeEnvelopeR};
     bpvConfig.buildToRadiusZero = true;
     auto beamPipeVolumeBuilder =
         std::make_shared<const Acts::CylinderVolumeBuilder>(
@@ -262,8 +263,8 @@ std::shared_ptr<const Acts::TrackingGeometry> buildTGeoDetector(
     volumeConfig.trackingVolumeHelper = cylinderVolumeHelper;
     volumeConfig.volumeName = lbc.configurationName;
     volumeConfig.buildToRadiusZero = volumeBuilders.empty();
-    volumeConfig.layerEnvelopeR = {1. * Acts::UnitConstants::mm,
-                                   5. * Acts::UnitConstants::mm};
+    volumeConfig.layerEnvelopeR = {config.layerEnvelopeR,
+                                   config.layerEnvelopeR};
     auto ringLayoutConfiguration =
         [&](const std::vector<Acts::TGeoLayerBuilder::LayerConfig>& lConfigs)
         -> void {

--- a/Examples/Python/src/Detector.cpp
+++ b/Examples/Python/src/Detector.cpp
@@ -203,6 +203,8 @@ void addDetector(Context& ctx) {
     ACTS_PYTHON_MEMBER(beamPipeRadius);
     ACTS_PYTHON_MEMBER(beamPipeHalflengthZ);
     ACTS_PYTHON_MEMBER(beamPipeLayerThickness);
+    ACTS_PYTHON_MEMBER(beampipeEnvelopeR);
+    ACTS_PYTHON_MEMBER(layerEnvelopeR);
     ACTS_PYTHON_MEMBER(unitScalor);
     ACTS_PYTHON_MEMBER(volumes);
     ACTS_PYTHON_STRUCT_END();


### PR DESCRIPTION
The idea of this PR is to make the radial envelope parameters of the layer/volume builder configurable. This is important for the geometries with closely located layers: the standard (and hardcoded) dimensions of the envelopes result in volume overlapping.