### PR TITLE
Add info about secondary particles at the time of the decay

### DIFF
--- a/Examples/Algorithms/Geant4/CMakeLists.txt
+++ b/Examples/Algorithms/Geant4/CMakeLists.txt
@@ -6,6 +6,7 @@ acts_add_library(
     src/MagneticFieldWrapper.cpp
     src/MaterialPhysicsList.cpp
     src/MaterialSteppingAction.cpp
+    src/DecaySteppingAction.cpp
     src/ParticleTrackingAction.cpp
     src/RegionCreator.cpp
     src/SensitiveSurfaceMapper.cpp

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/DecaySteppingAction.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/DecaySteppingAction.hpp
@@ -1,0 +1,67 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#pragma once
+
+#include "Acts/Utilities/Logger.hpp"
+
+#include <memory>
+
+#include <G4UserSteppingAction.hh>
+
+class G4Step;
+
+namespace ActsExamples::Geant4 {
+
+class EventStore;
+
+/// @class DecaySteppingAction
+///
+/// @brief Captures daughter particles at the exact moment of decay
+///
+/// This stepping action intercepts decay processes and stores information
+/// about daughter particles at their creation point (decay vertex), before
+/// any propagation through the detector material.
+class DecaySteppingAction final : public G4UserSteppingAction {
+ public:
+  /// @brief Configuration of the DecaySteppingAction
+  struct Config {
+    /// Event store to write to
+    EventStore* eventStore = nullptr;
+  };
+
+  /// Construct the stepping action
+  ///
+  /// @param cfg the configuration struct
+  /// @param logger the ACTS logging instance
+  DecaySteppingAction(const Config& cfg,
+                      std::unique_ptr<const Acts::Logger> logger =
+                          Acts::getDefaultLogger("DecaySteppingAction",
+                                                  Acts::Logging::INFO));
+  ~DecaySteppingAction() override = default;
+
+  /// Action per step
+  ///
+  /// @param step the Geant4 step of the particle
+  void UserSteppingAction(const G4Step* step) override;
+
+ protected:
+  /// Access the event store
+  EventStore& eventStore() const { return *m_cfg.eventStore; }
+
+  /// The logger instance
+  const Acts::Logger& logger() const { return *m_logger; }
+
+ private:
+  /// The configuration
+  Config m_cfg;
+  /// The logging instance
+  std::unique_ptr<const Acts::Logger> m_logger;
+};
+
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/EventStore.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/EventStore.hpp
@@ -27,6 +27,16 @@ class WhiteBoard;
 
 namespace ActsExamples::Geant4 {
 
+/// Structure to store decay vertex information for daughter particles
+struct DecayVertexInfo {
+  SimBarcode barcode;          // Daughter's barcode
+  SimBarcode parentBarcode;    // Mother/parent particle's barcode
+  Acts::Vector3 position;      // Decay vertex position
+  double time;                 // Decay time
+  Acts::Vector3 momentum;      // Daughter momentum at decay
+  int pdg;                     // Daughter PDG code
+};
+
 /// Common event store for all Geant4 related sub algorithms
 struct EventStore {
  public:
@@ -43,6 +53,9 @@ struct EventStore {
 
   /// Simulated particle collection
   ParticleContainer particlesSimulated;
+
+  /// Particle collection at the moment of decay
+  ParticleContainer particlesDecay;
 
   /// The hits in sensitive detectors
   SimHitContainer::sequence_type hits;
@@ -68,6 +81,14 @@ struct EventStore {
   std::unordered_map<G4int, SimBarcode> trackIdMapping;
   /// Geant4 Track ID subparticle counter (for subparticle indexing)
   std::unordered_map<G4int, std::size_t> trackIdSubparticleCount;
+
+  /// Map from parent track ID to list of decay daughters with their vertex info
+  /// Key: parent Geant4 track ID, Value: vector of daughter decay info
+  std::unordered_map<G4int, std::vector<DecayVertexInfo>> decayVertexMap;
+
+  /// Map from daughter barcode to parent barcode for decay particles
+  /// This allows easy lookup of mother particle for any decay daughter
+  std::unordered_map<SimBarcode, SimBarcode> daughterToMotherMap;
 
   /// Data handles to read particles from the whiteboard
   const ReadDataHandle<SimParticleContainer>* inputParticles{nullptr};

--- a/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Simulation.hpp
+++ b/Examples/Algorithms/Geant4/include/ActsExamples/Geant4/Geant4Simulation.hpp
@@ -124,6 +124,9 @@ class Geant4Simulation final : public Geant4SimulationBase {
     /// Name of the output collection : simulated particles
     std::string outputParticles = "particles_simulated";
 
+    /// Name of the output collection : simulated decay particles
+    std::string outputParticlesDecay = "particles_decay";
+
     /// Name of the output collection : propagation records (debugging)
     std::string outputPropagationSummaries = "propagation_summaries";
 
@@ -152,6 +155,9 @@ class Geant4Simulation final : public Geant4SimulationBase {
     bool keepParticlesWithoutHits = true;
 
     bool recordPropagationSummaries = false;
+
+    /// Optional: output file path for daughter-to-mother particle ID mapping (CSV format)
+    std::optional<std::string> outputDaughterToMotherMap = std::nullopt;
   };
 
   /// Simulation constructor
@@ -180,6 +186,8 @@ class Geant4Simulation final : public Geant4SimulationBase {
 
   WriteDataHandle<SimParticleContainer> m_outputParticles{this,
                                                           "OutputParticles"};
+  WriteDataHandle<SimParticleContainer> m_outputParticlesDecay{
+      this, "OutputParticlesDecay"};
   WriteDataHandle<SimHitContainer> m_outputSimHits{this, "OutputSimHIts"};
 
   WriteDataHandle<PropagationSummaries> m_outputPropagationSummaries{

--- a/Examples/Algorithms/Geant4/src/DecaySteppingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/DecaySteppingAction.cpp
@@ -1,0 +1,151 @@
+// This file is part of the ACTS project.
+//
+// Copyright (C) 2016 CERN for the benefit of the ACTS project
+//
+// This Source Code Form is subject to the terms of the Mozilla Public
+// License, v. 2.0. If a copy of the MPL was not distributed with this
+// file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+#include "ActsExamples/Geant4/DecaySteppingAction.hpp"
+
+#include "Acts/Definitions/PdgParticle.hpp"
+#include "Acts/Definitions/Units.hpp"
+#include "ActsExamples/EventData/SimParticle.hpp"
+#include "ActsExamples/Geant4/EventStore.hpp"
+#include "ActsFatras/EventData/Barcode.hpp"
+
+#include <G4ParticleDefinition.hh>
+#include <G4Step.hh>
+#include <G4Track.hh>
+#include <G4VProcess.hh>
+
+namespace ActsExamples::Geant4 {
+
+DecaySteppingAction::DecaySteppingAction(
+    const Config& cfg, std::unique_ptr<const Acts::Logger> logger)
+    : G4UserSteppingAction(), m_cfg(cfg), m_logger(std::move(logger)) {}
+
+void DecaySteppingAction::UserSteppingAction(const G4Step* step) {
+  // Get the track and process information
+  G4Track* track = step->GetTrack();
+  const G4VProcess* process = step->GetPostStepPoint()->GetProcessDefinedStep();
+  
+  if (process == nullptr) {
+    return;
+  }
+
+  // Check if this is a decay process
+  G4String processName = process->GetProcessName();
+  if (processName != "Decay") {
+    return;
+  }
+
+  // Get the parent particle barcode
+  G4int trackId = track->GetTrackID();
+  if (!eventStore().trackIdMapping.contains(trackId)) {
+    return;
+  }
+  
+  SimBarcode parentBarcode = eventStore().trackIdMapping.at(trackId);
+
+  // Get the number of secondaries created in this step
+  const G4TrackVector* secondaries = step->GetSecondary();
+  if (secondaries == nullptr || secondaries->size() == 0) {
+    return;
+  }
+
+  // Unit conversions G4->ACTS
+  constexpr double convertTime = Acts::UnitConstants::ns / CLHEP::ns;
+  constexpr double convertLength = Acts::UnitConstants::mm / CLHEP::mm;
+  constexpr double convertEnergy = Acts::UnitConstants::GeV / CLHEP::GeV;
+
+  // Get decay vertex information from the post-step point (where decay happens)
+  G4ThreeVector decayPosition = convertLength * step->GetPostStepPoint()->GetPosition();
+  G4double decayTime = convertTime * step->GetPostStepPoint()->GetGlobalTime();
+
+  ACTS_VERBOSE("Decay detected: parent barcode " << parentBarcode 
+               << ", parent trackID " << trackId
+               << ", PDG " << track->GetParticleDefinition()->GetPDGEncoding()
+               << ", " << secondaries->size() << " daughters"
+               << " at position (" << decayPosition.x() << ", " 
+               << decayPosition.y() << ", " << decayPosition.z() << ")");
+
+  // Create a list to store decay daughters for this parent
+  std::vector<DecayVertexInfo> decayDaughters;
+
+  // Store information about each daughter particle at the decay vertex
+  int daughterIndex = 0;
+  for (const auto* secondary : *secondaries) {
+    // Get daughter particle information
+    const G4ParticleDefinition* particleDef = secondary->GetParticleDefinition();
+    G4int pdg = particleDef->GetPDGEncoding();
+    G4double charge = particleDef->GetPDGCharge();
+    G4double mass = convertEnergy * particleDef->GetPDGMass();
+    
+    // Get momentum at creation (decay vertex)
+    G4ThreeVector momentum = secondary->GetMomentum();
+    G4double px = convertEnergy * momentum.x();
+    G4double py = convertEnergy * momentum.y();
+    G4double pz = convertEnergy * momentum.z();
+    G4double p = convertEnergy * momentum.mag();
+
+    if(p<1.0e-04)
+    {
+      ACTS_WARNING("Daughter " << daughterIndex << " has very low momentum p = " << p << " GeV. Skipping.");
+      continue;
+    }
+    
+    // Get direction
+    G4ThreeVector direction = momentum.unit();
+
+    // Create unique barcode for each daughter (will be used by ParticleTrackingAction)
+    SimBarcode daughterBarcode = parentBarcode.makeDescendant();
+    
+    // Generate unique subparticle ID for this daughter
+    auto key = EventStore::BarcodeWithoutSubparticle::Zeros();
+    key.set(0, daughterBarcode.vertexPrimary())
+        .set(1, daughterBarcode.vertexSecondary())
+        .set(2, daughterBarcode.particle())
+        .set(3, daughterBarcode.generation());
+    daughterBarcode.setSubParticle(++eventStore().subparticleMap[key]);
+    
+    // Store decay vertex info for this daughter
+    DecayVertexInfo decayInfo;
+    decayInfo.barcode = daughterBarcode;
+    decayInfo.parentBarcode = parentBarcode;  // Store parent barcode
+    decayInfo.position = Acts::Vector3(decayPosition.x(), decayPosition.y(), decayPosition.z());
+    decayInfo.time = decayTime;
+    decayInfo.momentum = Acts::Vector3(px, py, pz);
+    decayInfo.pdg = pdg;
+    decayDaughters.push_back(decayInfo);
+    
+    // Create SimParticleState for the daughter at decay vertex for particlesDecay collection
+    SimParticleState daughterState(daughterBarcode, Acts::PdgParticle{pdg}, charge, mass);
+    daughterState.setPosition4(decayPosition.x(), decayPosition.y(), decayPosition.z(), decayTime);
+    daughterState.setDirection(direction.x(), direction.y(), direction.z());
+    daughterState.setAbsoluteMomentum(p);
+    
+    // Create a SimParticle with both initial and final state set to decay vertex
+    SimParticle daughterParticle(daughterState, daughterState);
+    
+    // Store in particlesDecay collection
+    eventStore().particlesDecay.insert(daughterParticle);
+    
+    // Store daughter-to-mother barcode mapping
+    eventStore().daughterToMotherMap[daughterBarcode] = parentBarcode;
+    
+    ACTS_VERBOSE("  Daughter " << daughterIndex << ": barcode " << daughterBarcode 
+                 << ", parent barcode " << parentBarcode
+                 << ", PDG " << pdg 
+                 << ", p = " << p << " GeV"
+                 << ", px = " << px << ", py = " << py << ", pz = " << pz);
+    
+    daughterIndex++;
+  }
+  
+  // Store the decay daughters indexed by parent track ID
+  // ParticleTrackingAction will retrieve them when daughters start tracking
+  eventStore().decayVertexMap[trackId] = decayDaughters;
+}
+
+}  // namespace ActsExamples::Geant4

--- a/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
+++ b/Examples/Algorithms/Geant4/src/Geant4Simulation.cpp
@@ -22,6 +22,7 @@
 #include "ActsExamples/Geant4/MaterialSteppingAction.hpp"
 #include "ActsExamples/Geant4/ParticleKillAction.hpp"
 #include "ActsExamples/Geant4/ParticleTrackingAction.hpp"
+#include "ActsExamples/Geant4/DecaySteppingAction.hpp"
 #include "ActsExamples/Geant4/SensitiveSteppingAction.hpp"
 #include "ActsExamples/Geant4/SensitiveSurfaceMapper.hpp"
 #include "ActsExamples/Geant4/SimParticleTranslation.hpp"
@@ -29,6 +30,7 @@
 
 #include <stdexcept>
 #include <utility>
+#include <fstream>
 
 #include <G4FieldManager.hh>
 #include <G4RunManager.hh>
@@ -230,6 +232,12 @@ Geant4Simulation::Geant4Simulation(const Config& cfg,
     steppingCfg.actions.push_back(std::make_unique<Geant4::ParticleKillAction>(
         particleKillCfg, m_logger->cloneWithSuffix("Killer")));
 
+    // Add decay stepping action to capture daughter particles at decay vertex
+    Geant4::DecaySteppingAction::Config decayCfg;
+    decayCfg.eventStore = m_eventStore.get();
+    steppingCfg.actions.push_back(std::make_unique<Geant4::DecaySteppingAction>(
+        decayCfg, m_logger->cloneWithSuffix("DecayStepping")));
+
     auto sensitiveSteppingAction =
         std::make_unique<Geant4::SensitiveSteppingAction>(
             stepCfg, m_logger->cloneWithSuffix("SensitiveStepping"));
@@ -289,6 +297,7 @@ Geant4Simulation::Geant4Simulation(const Config& cfg,
   m_inputParticles.initialize(cfg.inputParticles);
   m_outputSimHits.initialize(cfg.outputSimHits);
   m_outputParticles.initialize(cfg.outputParticles);
+  m_outputParticlesDecay.initialize(cfg.outputParticlesDecay);
 
   if (cfg.recordPropagationSummaries) {
     m_outputPropagationSummaries.initialize(cfg.outputPropagationSummaries);
@@ -307,6 +316,27 @@ ProcessCode Geant4Simulation::execute(const AlgorithmContext& ctx) const {
   m_outputParticles(
       ctx, SimParticleContainer(eventStore().particlesSimulated.begin(),
                                 eventStore().particlesSimulated.end()));
+
+  m_outputParticlesDecay(
+      ctx, SimParticleContainer(eventStore().particlesDecay.begin(),
+                                eventStore().particlesDecay.end()));
+
+  // Write daughter-to-mother mapping for decay particles
+  if (!eventStore().daughterToMotherMap.empty() && m_cfg.outputDaughterToMotherMap.has_value()) {
+    std::ofstream mapFile(m_cfg.outputDaughterToMotherMap.value(), 
+                         ctx.eventNumber == 0 ? std::ios::out : std::ios::app);
+    if (mapFile.is_open()) {
+      // Write header only for first event
+      if (ctx.eventNumber == 0) {
+        mapFile << "event_id,daughter_id,mother_id\n";
+      }
+      // Write mappings
+      for (const auto& [daughter, mother] : eventStore().daughterToMotherMap) {
+        mapFile << ctx.eventNumber << "," << daughter.value() << "," << mother.value() << "\n";
+      }
+      mapFile.close();
+    }
+  }
 
 #if BOOST_VERSION < 107800
   SimHitContainer container;

--- a/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
+++ b/Examples/Algorithms/Geant4/src/ParticleTrackingAction.cpp
@@ -43,15 +43,63 @@ void ParticleTrackingAction::PreUserTrackingAction(const G4Track* aTrack) {
     ACTS_WARNING("Hit buffer not empty after track");
   }
 
-  auto barcode = makeParticleId(aTrack->GetTrackID(), aTrack->GetParentID());
-
+  // Check if this is a daughter from a decay
+  G4int parentId = aTrack->GetParentID();
+  G4int pdg = aTrack->GetParticleDefinition()->GetPDGEncoding();
+  SimBarcode barcode;
+  
+  // Look up if parent has decay daughters registered
+  if (parentId > 0 && eventStore().decayVertexMap.contains(parentId)) {
+    auto& decayDaughters = eventStore().decayVertexMap.at(parentId);
+    
+    // Find matching daughter by PDG (and potentially other criteria if needed)
+    DecayVertexInfo* matchedDaughter = nullptr;
+    for (auto& daughter : decayDaughters) {
+      if (daughter.pdg == pdg) {
+        // Check if this barcode is not yet used
+        if (!eventStore().trackIdMapping.contains(aTrack->GetTrackID())) {
+          matchedDaughter = &daughter;
+          break;
+        }
+      }
+    }
+    
+    if (matchedDaughter) {
+      // Use the pre-assigned barcode from decay vertex
+      barcode = matchedDaughter->barcode;
+      eventStore().trackIdMapping[aTrack->GetTrackID()] = barcode;
+      
+      ACTS_VERBOSE("Matched decay daughter: trackID " << aTrack->GetTrackID()
+                   << ", barcode " << barcode
+                   << ", PDG " << pdg
+                   << " from parent trackID " << parentId);
+      
+      // Register in particlesInitial with decay vertex information
+      auto fatrasParticle = convert(*aTrack, barcode);
+      SimParticle particle(fatrasParticle, fatrasParticle);
+      auto [it, success] = eventStore().particlesInitial.insert(particle);
+      
+      if (!success) {
+        eventStore().particleIdCollisionsInitial++;
+        ACTS_WARNING("Particle ID collision with "
+                     << particle.particleId()
+                     << " detected for decay daughter. Skip particle");
+      }
+      return;
+    }
+  }
+  
+  // Not a decay daughter or no match found - use standard barcode creation
+  auto barcodeOpt = makeParticleId(aTrack->GetTrackID(), aTrack->GetParentID());
+  
   // There is already a warning printed in the makeParticleId function if this
   // indicates a failure
-  if (!barcode) {
+  if (!barcodeOpt) {
     return;
   }
+  barcode = *barcodeOpt;
 
-  auto fatrasParticle = convert(*aTrack, *barcode);
+  auto fatrasParticle = convert(*aTrack, barcode);
   SimParticle particle(fatrasParticle, fatrasParticle);
   auto [it, success] = eventStore().particlesInitial.insert(particle);
 

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
@@ -43,6 +43,9 @@ class RootParticleWriter final : public WriterT<SimParticleContainer> {
     std::string fileMode = "RECREATE";
     /// Name of the tree within the output file.
     std::string treeName = "particles";
+    /// Input map from daughter to mother particle IDs (optional)
+    /// If provided, will write mother_particle_id branch
+    std::string inputDaughterToMotherMap = "";
   };
 
   /// Construct the particle writer.
@@ -112,6 +115,9 @@ class RootParticleWriter final : public WriterT<SimParticleContainer> {
   std::vector<std::uint32_t> m_particle;
   std::vector<std::uint32_t> m_generation;
   std::vector<std::uint32_t> m_subParticle;
+
+  /// Mother/parent particle ID (0 if no mother, i.e., primary particle)
+  std::vector<std::uint64_t> m_motherParticleId;
 
   std::vector<std::int32_t> m_bc;
 

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -69,6 +69,8 @@ ActsExamples::RootParticleWriter::RootParticleWriter(
   m_outputTree->Branch("generation", &m_generation);
   m_outputTree->Branch("sub_particle", &m_subParticle);
 
+  m_outputTree->Branch("mother_particle_id", &m_motherParticleId);
+
   m_outputTree->Branch("bc", &m_bc);
 
   m_outputTree->Branch("e_loss", &m_eLoss);
@@ -144,6 +146,23 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
     m_generation.push_back(particle.particleId().generation());
     m_subParticle.push_back(particle.particleId().subParticle());
 
+    // Compute mother particle ID
+    // For primary particles (generation 0), mother ID is 0
+    // For secondary particles, reconstruct mother barcode from generation-1
+    std::uint64_t motherid = 0;
+    if (particle.particleId().generation() > 0) {
+      // Mother has one less generation, same vertex info
+      SimBarcode motherBarcode = SimBarcode(0u)
+          .setVertexPrimary(particle.particleId().vertexPrimary())
+          .setVertexSecondary(particle.particleId().vertexSecondary())
+          .setParticle(particle.particleId().particle())
+          .setGeneration(particle.particleId().generation() - 1);
+      // Note: we don't know the exact subParticle index of the mother
+      // This gives an approximate mother ID - exact matching requires the map
+      motherid = motherBarcode.value();
+    }
+    m_motherParticleId.push_back(motherid);
+
     m_bc.push_back(particle.initial().BC());
 
     m_eLoss.push_back(Acts::clampValue<float>(particle.energyLoss() /
@@ -186,6 +205,7 @@ ActsExamples::ProcessCode ActsExamples::RootParticleWriter::writeT(
   m_pathInL0.clear();
 
   m_bc.clear();
+  m_motherParticleId.clear();
 
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Python/python/acts/examples/simulation.py
+++ b/Examples/Python/python/acts/examples/simulation.py
@@ -520,6 +520,7 @@ def addFatras(
         s,
         alg.config.outputSimHits,
         outputParticles,
+        None,
         outputDirCsv,
         outputDirRoot,
         outputDirObj,
@@ -533,6 +534,7 @@ def addSimWriters(
     s: acts.examples.Sequencer,
     simHits: str = "simhits",
     particlesSimulated: str = "particles_simulated",
+    particlesDecay: Optional[str] = None,
     outputDirCsv: Optional[Union[Path, str]] = None,
     outputDirRoot: Optional[Union[Path, str]] = None,
     outputDirObj: Optional[Union[Path, str]] = None,
@@ -560,6 +562,15 @@ def addSimWriters(
                 outputStem="hits",
             )
         )
+        if particlesDecay is not None:
+            s.addWriter(
+                acts.examples.CsvParticleWriter(
+                    level=customLogLevel(),
+                    outputDir=str(outputDirCsv),
+                    inputParticles=particlesDecay,
+                    outputStem="particles_decay",
+                )
+            )
 
     if outputDirRoot is not None:
         outputDirRoot = Path(outputDirRoot)
@@ -572,6 +583,15 @@ def addSimWriters(
                 filePath=str(outputDirRoot / "particles_simulation.root"),
             )
         )
+        if particlesDecay is not None:
+            s.addWriter(
+                acts.examples.RootParticleWriter(
+                    level=customLogLevel(),
+                    inputParticles=particlesDecay,
+                    filePath=str(outputDirRoot / "particles_decay.root"),
+                )
+            )
+
         s.addWriter(
             acts.examples.RootSimHitWriter(
                 level=customLogLevel(),
@@ -608,6 +628,7 @@ def addGeant4(
     materialMappings: List[str] = ["Silicon"],
     inputParticles: str = "particles_generated_selected",
     outputParticles: str = "particles_simulated",
+    outputParticlesDecay: str = "particles_decay",
     outputSimHits: str = "simhits",
     recordHitsOfSecondaries=True, #False,#True, ### IA
     keepParticlesWithoutHits=False,#True, ### IA
@@ -665,6 +686,7 @@ def addGeant4(
         randomNumbers=rnd,
         inputParticles=inputParticles,
         outputParticles=outputParticles,
+        outputParticlesDecay=outputParticlesDecay,
         outputSimHits=outputSimHits,
         sensitiveSurfaceMapper=sensitiveMapper,
         magneticField=field,
@@ -690,6 +712,7 @@ def addGeant4(
         s,
         alg.config.outputSimHits,
         outputParticles,
+        outputParticlesDecay,
         outputDirCsv,
         outputDirRoot,
         outputDirObj,

--- a/Examples/Python/src/Geant4Component.cpp
+++ b/Examples/Python/src/Geant4Component.cpp
@@ -186,7 +186,7 @@ PYBIND11_MODULE(ActsPythonBindingsGeant4, mod) {
                          std::shared_ptr<Config>>(alg, "Config")
                   .def(py::init<>());
     ACTS_PYTHON_STRUCT(
-        c1, outputSimHits, outputParticles, outputPropagationSummaries,
+        c1, outputSimHits, outputParticles, outputParticlesDecay, outputPropagationSummaries,
         sensitiveSurfaceMapper, magneticField, physicsList, killVolume,
         killAfterTime, killSecondaries, recordHitsOfCharged,
         recordHitsOfNeutrals, recordHitsOfPrimaries, recordHitsOfSecondaries,


### PR DESCRIPTION
Add new output file, where information about secondary particles are stored on the time of the decay. For this a new class DecaySteppingAction is created. Moreover it is assured that the barcode of the same secondary particle stored in the new output file and particles_simulation.root remains the same. Each secondary particle can be linked to the mother particle with a barcode, now stored in the output file. 