### PR TITLE
Add minimal MC truth information for HF tagging

### DIFF
--- a/Core/include/Acts/Definitions/PdgParticle.hpp
+++ b/Core/include/Acts/Definitions/PdgParticle.hpp
@@ -124,6 +124,13 @@ enum class HadronType {
   Unknown = 12
 };
 
+/// Hadron heavy-flavour origin classification
+enum class HfOrigin : std::uint8_t {
+  None = 0,
+  Charm = 4,
+  Bottom = 5
+};
+
 /// Stream operator for HadronType
 /// @param os Output stream
 /// @param hadron The hadron type to output

--- a/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
@@ -10,7 +10,7 @@
 
 #include "ActsExamples/Utilities/GroupBy.hpp"
 #include "ActsFatras/EventData/Particle.hpp"
-#include "ActsFatras/EventData/SimulationOutcome.hpp"
+#include "ActsFatras/EventData/ParticleOutcome.hpp"
 
 #include <boost/container/flat_set.hpp>
 
@@ -74,7 +74,7 @@ class SimParticle final {
   }
 
   /// Set the process type that generated this particle.
-  SimParticle& setProcess(ActsFatras::GenerationProcess proc) {
+  SimParticle& setProcess(ActsFatras::ProcessType proc) {
     initialState().setProcess(proc);
     finalState().setProcess(proc);
     return *this;
@@ -103,13 +103,27 @@ class SimParticle final {
     finalState().setParticleId(barcode);
     return *this;
   }
+  /// Original particle index (to match HepMC).
+  SimParticle& setOrigParticleIdx(std::uint32_t idx) {
+    initialState().setOrigParticleIdx(idx);
+    finalState().setOrigParticleIdx(idx);
+    return *this;
+  }
+  /// Particle HF origin (0->none, 4->charm, 5->beauty)
+  SimParticle& setHfOrigin(Acts::HfOrigin origin) {
+    initialState().setHfOrigin(origin);
+    finalState().setHfOrigin(origin);
+    return *this;
+  }
 
   /// Particle identifier within an event.
   SimBarcode particleId() const { return initialState().particleId(); }
+  /// Original particle index (to match HepMC)
+  std::uint32_t origParticleIdx() const { return initialState().origParticleIdx(); }
+  /// Particle HF origin (0->none, 4->charm, 5->beauty)
+  Acts::HfOrigin hfOrigin() const { return initialState().hfOrigin(); }
   /// Which type of process generated this particle.
-  ActsFatras::GenerationProcess process() const {
-    return initialState().process();
-  }
+  ActsFatras::ProcessType process() const { return initialState().process(); }
   /// PDG particle number that identifies the type.
   Acts::PdgParticle pdg() const { return initialState().pdg(); }
   /// Absolute PDG particle number that identifies the type.
@@ -172,9 +186,7 @@ class SimParticle final {
   std::uint32_t numberOfHits() const { return finalState().numberOfHits(); }
 
   /// Particle outcome.
-  ActsFatras::SimulationOutcome outcome() const {
-    return finalState().outcome();
-  }
+  ActsFatras::ParticleOutcome outcome() const { return finalState().outcome(); }
 
  private:
   SimParticleState m_initial;

--- a/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
+++ b/Examples/Framework/include/ActsExamples/EventData/SimParticle.hpp
@@ -10,7 +10,7 @@
 
 #include "ActsExamples/Utilities/GroupBy.hpp"
 #include "ActsFatras/EventData/Particle.hpp"
-#include "ActsFatras/EventData/ParticleOutcome.hpp"
+#include "ActsFatras/EventData/SimulationOutcome.hpp"
 
 #include <boost/container/flat_set.hpp>
 
@@ -74,7 +74,7 @@ class SimParticle final {
   }
 
   /// Set the process type that generated this particle.
-  SimParticle& setProcess(ActsFatras::ProcessType proc) {
+  SimParticle& setProcess(ActsFatras::GenerationProcess proc) {
     initialState().setProcess(proc);
     finalState().setProcess(proc);
     return *this;
@@ -123,7 +123,9 @@ class SimParticle final {
   /// Particle HF origin (0->none, 4->charm, 5->beauty)
   Acts::HfOrigin hfOrigin() const { return initialState().hfOrigin(); }
   /// Which type of process generated this particle.
-  ActsFatras::ProcessType process() const { return initialState().process(); }
+  ActsFatras::GenerationProcess process() const {
+    return initialState().process();
+  }
   /// PDG particle number that identifies the type.
   Acts::PdgParticle pdg() const { return initialState().pdg(); }
   /// Absolute PDG particle number that identifies the type.
@@ -186,7 +188,9 @@ class SimParticle final {
   std::uint32_t numberOfHits() const { return finalState().numberOfHits(); }
 
   /// Particle outcome.
-  ActsFatras::ParticleOutcome outcome() const { return finalState().outcome(); }
+  ActsFatras::SimulationOutcome outcome() const {
+    return finalState().outcome();
+  }
 
  private:
   SimParticleState m_initial;

--- a/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3InputConverter.hpp
+++ b/Examples/Io/HepMC3/include/ActsExamples/Io/HepMC3/HepMC3InputConverter.hpp
@@ -19,6 +19,7 @@
 namespace HepMC3 {
 class GenEvent;
 class GenVertex;
+class GenParticle;
 }  // namespace HepMC3
 
 namespace ActsExamples {
@@ -50,6 +51,9 @@ class HepMC3InputConverter : public IAlgorithm {
 
     /// If true, check the consistency of the generated event.
     bool checkConsistency = false;
+
+    /// Search up to quark in HF tagging
+    bool searchUpToHfQuark = false;
   };
 
   explicit HepMC3InputConverter(
@@ -63,6 +67,8 @@ class HepMC3InputConverter : public IAlgorithm {
  private:
   void convertHepMC3ToInternalEdm(const AlgorithmContext& ctx,
                                   const HepMC3::GenEvent& genEvent) const;
+
+  Acts::HfOrigin checkHfOrigin(std::shared_ptr<const HepMC3::GenParticle> particle) const;
 
   void handleVertex(const HepMC3::GenVertex& genVertex, SimVertex& vertex,
                     std::vector<SimVertex>& vertices,

--- a/Examples/Io/HepMC3/src/HepMC3InputConverter.cpp
+++ b/Examples/Io/HepMC3/src/HepMC3InputConverter.cpp
@@ -27,6 +27,8 @@
 #pragma clang diagnostic pop
 #endif
 
+#include <unordered_set>
+
 using namespace Acts::UnitLiterals;
 
 namespace ActsExamples {
@@ -104,6 +106,56 @@ std::string printListing(const auto& vertices, const auto& particles) {
   return ss.str();
 };
 }  // namespace
+
+Acts::HfOrigin HepMC3InputConverter::checkHfOrigin(std::shared_ptr<const HepMC3::GenParticle> particleToCheck) const {
+
+  std::stack<std::shared_ptr<const HepMC3::GenParticle>> st;
+  std::unordered_set<int> visited;
+  st.push(particleToCheck);
+
+  bool isFromCharm{false};
+  while (!st.empty()) {
+    auto part = st.top();
+    st.pop();
+
+    if(!part) {
+      continue;
+    }
+
+    if (visited.count(part->id())) {
+      continue;
+    }
+    visited.insert(part->id());
+
+    int pdgCode = std::abs(part->pid());
+
+    // --- beauty PDG IDs ---
+    if (static_cast<Acts::HfOrigin>(pdgCode / 100) == Acts::HfOrigin::Bottom || static_cast<Acts::HfOrigin>(pdgCode / 1000) == Acts::HfOrigin::Bottom || (m_cfg.searchUpToHfQuark && static_cast<Acts::HfOrigin>(pdgCode) == Acts::HfOrigin::Bottom)) {
+      return Acts::HfOrigin::Bottom;
+    }
+
+    // --- charm PDG IDs ---
+    if (static_cast<Acts::HfOrigin>(pdgCode / 100) == Acts::HfOrigin::Charm || static_cast<Acts::HfOrigin>(pdgCode / 1000) == Acts::HfOrigin::Charm || (m_cfg.searchUpToHfQuark && static_cast<Acts::HfOrigin>(pdgCode / 100) == Acts::HfOrigin::Charm)) {
+      isFromCharm = true; // we do not return directly becayse B -> D -> X should be tagged as from beauty and not charm
+    }
+
+    // go to parents
+    auto vtx = part->production_vertex();
+    if (!vtx) {
+      continue;
+    }
+
+    for (auto parent : vtx->particles_in()) {
+      st.push(parent);
+    }
+  }
+
+  if (isFromCharm) {
+    return Acts::HfOrigin::Charm;
+  }
+
+  return Acts::HfOrigin::None;
+}
 
 void HepMC3InputConverter::handleVertex(const HepMC3::GenVertex& genVertex,
                                         SimVertex& vertex,
@@ -194,6 +246,8 @@ void HepMC3InputConverter::handleVertex(const HepMC3::GenVertex& genVertex,
 
       SimParticle simParticle{particleId, pdg, charge, mass};
       simParticle.initialState().setPosition4(vertex.position4);
+      simParticle.setOrigParticleIdx(particle->id());
+      simParticle.setHfOrigin(checkHfOrigin(particle));
 
       const HepMC3::FourVector& genMomentum = particle->momentum();
       Acts::Vector3 momentum{genMomentum.px() * 1_GeV, genMomentum.py() * 1_GeV,

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleReader.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleReader.hpp
@@ -112,6 +112,8 @@ class RootParticleReader : public IReader {
   BranchVector<std::uint32_t> m_particle;
   BranchVector<std::uint32_t> m_generation;
   BranchVector<std::uint32_t> m_subParticle;
+  BranchVector<std::uint32_t> m_origParticleIdx;
+  BranchVector<std::uint8_t> m_hfOrigin;
 
   BranchVector<float> m_eLoss;
   BranchVector<float> m_pathInX0;

--- a/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
+++ b/Examples/Io/Root/include/ActsExamples/Io/Root/RootParticleWriter.hpp
@@ -142,6 +142,9 @@ class RootParticleWriter final : public WriterT<SimParticleContainer> {
   std::vector<std::uint32_t> m_generation;
   std::vector<std::uint32_t> m_subParticle;
 
+  std::vector<std::uint32_t> m_origParticleIdx;
+  std::vector<std::uint8_t> m_hfOrigin;
+
   /// Total energy loss in GeV.
   std::vector<float> m_eLoss;
   /// Accumulated material

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -13,8 +13,8 @@
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
 #include "ActsExamples/Io/Root/RootUtility.hpp"
-#include "ActsFatras/EventData/GenerationProcess.hpp"
-#include "ActsFatras/EventData/SimulationOutcome.hpp"
+#include "ActsFatras/EventData/ParticleOutcome.hpp"
+#include "ActsFatras/EventData/ProcessType.hpp"
 
 #include <iostream>
 #include <stdexcept>
@@ -62,6 +62,8 @@ RootParticleReader::RootParticleReader(const RootParticleReader::Config& config,
   m_inputChain->SetBranchAddress("particle", &m_particle.get());
   m_inputChain->SetBranchAddress("generation", &m_generation.get());
   m_inputChain->SetBranchAddress("sub_particle", &m_subParticle.get());
+  m_inputChain->SetBranchAddress("orig_part_idx", &m_origParticleIdx.get());
+  m_inputChain->SetBranchAddress("hf_origin", &m_hfOrigin.get());
 
   m_inputChain->SetBranchAddress("e_loss", &m_eLoss.get());
   m_inputChain->SetBranchAddress("total_x0", &m_pathInX0.get());
@@ -121,8 +123,7 @@ ProcessCode RootParticleReader::read(const AlgorithmContext& context) {
   for (unsigned int i = 0; i < nParticles; i++) {
     SimParticle p;
 
-    p.setProcess(
-        static_cast<ActsFatras::GenerationProcess>((*m_process).at(i)));
+    p.setProcess(static_cast<ActsFatras::ProcessType>((*m_process).at(i)));
     p.setPdg(static_cast<Acts::PdgParticle>((*m_particleType).at(i)));
     p.setCharge((*m_q).at(i) * Acts::UnitConstants::e);
     p.setMass((*m_m).at(i) * Acts::UnitConstants::GeV);
@@ -132,6 +133,9 @@ ProcessCode RootParticleReader::read(const AlgorithmContext& context) {
                         .withParticle((*m_particle).at(i))
                         .withGeneration((*m_generation).at(i))
                         .withSubParticle((*m_subParticle).at(i)));
+
+    p.setOrigParticleIdx((*m_origParticleIdx).at(i));
+    p.setHfOrigin(static_cast<Acts::HfOrigin>((*m_hfOrigin).at(i)));
 
     SimParticleState& initialState = p.initialState();
 
@@ -150,7 +154,7 @@ ProcessCode RootParticleReader::read(const AlgorithmContext& context) {
                                  (*m_pathInL0).at(i) * Acts::UnitConstants::mm);
     finalState.setNumberOfHits((*m_numberOfHits).at(i));
     finalState.setOutcome(
-        static_cast<ActsFatras::SimulationOutcome>((*m_outcome).at(i)));
+        static_cast<ActsFatras::ParticleOutcome>((*m_outcome).at(i)));
 
     particles.insert(p);
   }

--- a/Examples/Io/Root/src/RootParticleReader.cpp
+++ b/Examples/Io/Root/src/RootParticleReader.cpp
@@ -13,8 +13,8 @@
 #include "ActsExamples/EventData/SimParticle.hpp"
 #include "ActsExamples/Framework/AlgorithmContext.hpp"
 #include "ActsExamples/Io/Root/RootUtility.hpp"
-#include "ActsFatras/EventData/ParticleOutcome.hpp"
-#include "ActsFatras/EventData/ProcessType.hpp"
+#include "ActsFatras/EventData/GenerationProcess.hpp"
+#include "ActsFatras/EventData/SimulationOutcome.hpp"
 
 #include <iostream>
 #include <stdexcept>
@@ -123,7 +123,8 @@ ProcessCode RootParticleReader::read(const AlgorithmContext& context) {
   for (unsigned int i = 0; i < nParticles; i++) {
     SimParticle p;
 
-    p.setProcess(static_cast<ActsFatras::ProcessType>((*m_process).at(i)));
+    p.setProcess(
+        static_cast<ActsFatras::GenerationProcess>((*m_process).at(i)));
     p.setPdg(static_cast<Acts::PdgParticle>((*m_particleType).at(i)));
     p.setCharge((*m_q).at(i) * Acts::UnitConstants::e);
     p.setMass((*m_m).at(i) * Acts::UnitConstants::GeV);
@@ -154,7 +155,7 @@ ProcessCode RootParticleReader::read(const AlgorithmContext& context) {
                                  (*m_pathInL0).at(i) * Acts::UnitConstants::mm);
     finalState.setNumberOfHits((*m_numberOfHits).at(i));
     finalState.setOutcome(
-        static_cast<ActsFatras::ParticleOutcome>((*m_outcome).at(i)));
+        static_cast<ActsFatras::SimulationOutcome>((*m_outcome).at(i)));
 
     particles.insert(p);
   }

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -10,6 +10,7 @@
 
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Definitions/Units.hpp"
+#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/SympyStepper.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
@@ -75,6 +76,8 @@ RootParticleWriter::RootParticleWriter(const RootParticleWriter::Config& cfg,
   m_outputTree->Branch("particle", &m_particle);
   m_outputTree->Branch("generation", &m_generation);
   m_outputTree->Branch("sub_particle", &m_subParticle);
+  m_outputTree->Branch("orig_part_idx", &m_origParticleIdx);
+  m_outputTree->Branch("hf_origin", &m_hfOrigin);
 
   if (m_cfg.writeHelixParameters) {
     m_outputTree->Branch("perigee_d0", &m_perigeeD0);
@@ -122,6 +125,8 @@ ProcessCode RootParticleWriter::writeT(const AlgorithmContext& ctx,
   m_eventId = ctx.eventNumber;
   for (const auto& particle : particles) {
     m_particleHash.push_back(particle.particleId().hash());
+    m_origParticleIdx.push_back(particle.origParticleIdx());
+    m_hfOrigin.push_back(static_cast<std::uint8_t>(particle.hfOrigin()));
     m_particleType.push_back(particle.pdg());
     m_process.push_back(static_cast<std::uint32_t>(particle.process()));
     // position
@@ -357,6 +362,8 @@ ProcessCode RootParticleWriter::writeT(const AlgorithmContext& ctx,
     m_perigeeEta.clear();
     m_perigeePt.clear();
   }
+
+  m_origParticleIdx.clear();
 
   return ProcessCode::SUCCESS;
 }

--- a/Examples/Io/Root/src/RootParticleWriter.cpp
+++ b/Examples/Io/Root/src/RootParticleWriter.cpp
@@ -10,7 +10,6 @@
 
 #include "Acts/Definitions/TrackParametrization.hpp"
 #include "Acts/Definitions/Units.hpp"
-#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Propagator/Propagator.hpp"
 #include "Acts/Propagator/SympyStepper.hpp"
 #include "Acts/Surfaces/PerigeeSurface.hpp"
@@ -364,6 +363,7 @@ ProcessCode RootParticleWriter::writeT(const AlgorithmContext& ctx,
   }
 
   m_origParticleIdx.clear();
+  m_hfOrigin.clear();
 
   return ProcessCode::SUCCESS;
 }

--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -12,15 +12,15 @@
 #include "Acts/Definitions/Common.hpp"
 #include "Acts/Definitions/PdgParticle.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
+#include "Acts/EventData/BoundTrackParameters.hpp"
 #include "Acts/EventData/ParticleHypothesis.hpp"
-#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/MathHelpers.hpp"
 #include "Acts/Utilities/VectorHelpers.hpp"
 #include "ActsFatras/EventData/Barcode.hpp"
-#include "ActsFatras/EventData/ParticleOutcome.hpp"
-#include "ActsFatras/EventData/ProcessType.hpp"
+#include "ActsFatras/EventData/GenerationProcess.hpp"
+#include "ActsFatras/EventData/SimulationOutcome.hpp"
 
 #include <cmath>
 #include <iosfwd>
@@ -78,10 +78,20 @@ class Particle {
     return p;
   }
 
+  /// Kill the particle by setting the outcome to a non-alive status.
+  /// @param outcome The outcome status to set for the killed particle (must not be Alive)
+  /// @throws std::invalid_argument if the provided outcome is Alive
+  void killParticle(SimulationOutcome outcome) {
+    if (outcome == SimulationOutcome::Alive) {
+      throw std::invalid_argument("Cannot kill particle with outcome 'Alive'.");
+    }
+    m_outcome = outcome;
+  }
+
   /// Set the process type that generated this particle.
   /// @param proc Process type that generated this particle
   /// @return Reference to this particle for method chaining
-  Particle &setProcess(ProcessType proc) {
+  Particle &setProcess(GenerationProcess proc) {
     m_process = proc;
     return *this;
   }
@@ -111,20 +121,6 @@ class Particle {
   /// @return Reference to this particle for method chaining
   Particle &setParticleId(Barcode barcode) {
     m_particleId = barcode;
-    return *this;
-  }
-  /// Set the particle HF origin (0->none, 4->charm, 5->beauty) 
-  /// @param orig particle HF origin (0->none, 4->charm, 5->beauty) 
-  /// @return Reference to this particle in HepMC file
-  Particle &setHfOrigin(Acts::HfOrigin orig) {
-    m_hfOrigin = orig;
-    return *this;
-  }
-  /// Set the particle ID.
-  /// @param idx Original particle index (to match HepMC file)
-  /// @return Reference to this particle in HepMC file
-  Particle &setOrigParticleIdx(std::uint32_t idx) {
-    m_origParticleIdx = idx;
     return *this;
   }
   /// Set the space-time position four-vector.
@@ -179,22 +175,33 @@ class Particle {
   /// Set the absolute momentum.
   /// @param absMomentum Absolute momentum magnitude
   /// @return Reference to this particle for method chaining
+  /// @throws std::invalid_argument if absMomentum is negative
   Particle &setAbsoluteMomentum(double absMomentum) {
+    if (absMomentum < 0) {
+      throw std::invalid_argument("Absolute momentum cannot be negative.");
+    }
     m_absMomentum = absMomentum;
     return *this;
   }
 
-  /// Change the energy by the given amount.
-  ///
-  /// Energy loss corresponds to a negative change. If the updated energy
-  /// would result in an unphysical value, the particle is put to rest, i.e.
-  /// its absolute momentum is set to zero.
-  /// @param delta Energy change (negative for energy loss)
+  /// Reduce the energy by the given amount. If the energy loss exceeds the
+  /// current energy, the particle is killed with the specified outcome. If
+  /// stopping the particle was not expected (stoppedOutcome is Alive), an
+  /// exception is thrown.
+  /// @param delta The energy loss amount to subtract from the current energy
+  /// @param stoppedOutcome The outcome to set if the energy loss exceeds the current energy
   /// @return Reference to this particle for method chaining
-  Particle &correctEnergy(double delta) {
-    const auto newEnergy = std::hypot(m_mass, m_absMomentum) + delta;
+  /// @throws std::invalid_argument if the energy loss exceeds the current energy and stoppedOutcome is Alive
+  Particle &loseEnergy(double delta, SimulationOutcome stoppedOutcome =
+                                         SimulationOutcome::Alive) {
+    const double newEnergy = energy() - delta;
     if (newEnergy <= m_mass) {
-      m_absMomentum = 0.;
+      if (stoppedOutcome == SimulationOutcome::Alive) {
+        throw std::invalid_argument(
+            "Energy loss cannot exceed the current energy of the particle if "
+            "the particle is to remain alive.");
+      }
+      killParticle(stoppedOutcome);
     } else {
       m_absMomentum = Acts::fastCathetus(newEnergy, m_mass);
     }
@@ -212,7 +219,7 @@ class Particle {
   Acts::HfOrigin hfOrigin() const { return m_hfOrigin; }
   /// Which type of process generated this particle.
   /// @return The process type that generated this particle
-  ProcessType process() const { return m_process; }
+  GenerationProcess process() const { return m_process; }
   /// PDG particle number that identifies the type.
   /// @return The PDG particle identifier
   Acts::PdgParticle pdg() const { return m_pdg; }
@@ -236,7 +243,7 @@ class Particle {
   Acts::ParticleHypothesis hypothesis() const {
     return Acts::ParticleHypothesis(
         absolutePdg(), static_cast<float>(mass()),
-        Acts::AnyCharge{static_cast<float>(absoluteCharge())});
+        Acts::ChargeHypothesis{static_cast<float>(absoluteCharge())});
   }
   /// Particl qOverP.
   /// @return The charge over momentum ratio
@@ -290,7 +297,7 @@ class Particle {
 
   /// Check if the particle is alive, i.e. is not at rest.
   /// @return True if particle has non-zero momentum, false otherwise
-  bool isAlive() const { return 0. < m_absMomentum; }
+  bool isAlive() const { return m_outcome == SimulationOutcome::Alive; }
 
   /// Check if this is a secondary particle.
   /// @return True if particle is a secondary (has non-zero vertex secondary, generation, or sub-particle), false otherwise
@@ -390,35 +397,35 @@ class Particle {
   ///
   /// @param outcome outcome code
   /// @return Reference to this particle for method chaining
-  Particle &setOutcome(ParticleOutcome outcome) {
+  Particle &setOutcome(SimulationOutcome outcome) {
     m_outcome = outcome;
     return *this;
   }
 
   /// Particle outcome.
   /// @return The outcome status of this particle
-  ParticleOutcome outcome() const { return m_outcome; }
+  SimulationOutcome outcome() const { return m_outcome; }
 
  private:
   // identity, i.e. things that do not change over the particle lifetime.
   /// Particle identifier within the event.
   Barcode m_particleId;
   /// Process type specifier.
-  ProcessType m_process = ProcessType::eUndefined;
+  GenerationProcess m_process = GenerationProcess::eUndefined;
   /// PDG particle number.
   Acts::PdgParticle m_pdg = Acts::PdgParticle::eInvalid;
   // Particle charge and mass.
-  double m_charge = 0.;
-  double m_mass = 0.;
+  double m_charge = 0;
+  double m_mass = 0;
   // kinematics, i.e. things that change over the particle lifetime.
   Acts::Vector3 m_direction = Acts::Vector3::UnitZ();
-  double m_absMomentum = 0.;
+  double m_absMomentum = 0;
   Acts::Vector4 m_position4 = Acts::Vector4::Zero();
   /// proper time in the particle rest frame
-  double m_properTime = 0.;
+  double m_properTime = 0;
   // accumulated material
-  double m_pathInX0 = 0.;
-  double m_pathInL0 = 0.;
+  double m_pathInX0 = 0;
+  double m_pathInL0 = 0;
   /// number of hits
   std::uint32_t m_numberOfHits = 0;
   /// particle index to match the HepMC file
@@ -428,7 +435,7 @@ class Particle {
   /// reference surface
   const Acts::Surface *m_referenceSurface{nullptr};
   /// outcome
-  ParticleOutcome m_outcome = ParticleOutcome::Alive;
+  SimulationOutcome m_outcome = SimulationOutcome::Alive;
 };
 
 /// Print particle to output stream

--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -12,15 +12,15 @@
 #include "Acts/Definitions/Common.hpp"
 #include "Acts/Definitions/PdgParticle.hpp"
 #include "Acts/Definitions/TrackParametrization.hpp"
-#include "Acts/EventData/BoundTrackParameters.hpp"
 #include "Acts/EventData/ParticleHypothesis.hpp"
+#include "Acts/EventData/TrackParameters.hpp"
 #include "Acts/Geometry/GeometryContext.hpp"
 #include "Acts/Surfaces/Surface.hpp"
 #include "Acts/Utilities/MathHelpers.hpp"
 #include "Acts/Utilities/VectorHelpers.hpp"
 #include "ActsFatras/EventData/Barcode.hpp"
-#include "ActsFatras/EventData/GenerationProcess.hpp"
-#include "ActsFatras/EventData/SimulationOutcome.hpp"
+#include "ActsFatras/EventData/ParticleOutcome.hpp"
+#include "ActsFatras/EventData/ProcessType.hpp"
 
 #include <cmath>
 #include <iosfwd>
@@ -78,20 +78,10 @@ class Particle {
     return p;
   }
 
-  /// Kill the particle by setting the outcome to a non-alive status.
-  /// @param outcome The outcome status to set for the killed particle (must not be Alive)
-  /// @throws std::invalid_argument if the provided outcome is Alive
-  void killParticle(SimulationOutcome outcome) {
-    if (outcome == SimulationOutcome::Alive) {
-      throw std::invalid_argument("Cannot kill particle with outcome 'Alive'.");
-    }
-    m_outcome = outcome;
-  }
-
   /// Set the process type that generated this particle.
   /// @param proc Process type that generated this particle
   /// @return Reference to this particle for method chaining
-  Particle &setProcess(GenerationProcess proc) {
+  Particle &setProcess(ProcessType proc) {
     m_process = proc;
     return *this;
   }
@@ -121,6 +111,20 @@ class Particle {
   /// @return Reference to this particle for method chaining
   Particle &setParticleId(Barcode barcode) {
     m_particleId = barcode;
+    return *this;
+  }
+  /// Set the particle HF origin (0->none, 4->charm, 5->beauty) 
+  /// @param orig particle HF origin (0->none, 4->charm, 5->beauty) 
+  /// @return Reference to this particle in HepMC file
+  Particle &setHfOrigin(Acts::HfOrigin orig) {
+    m_hfOrigin = orig;
+    return *this;
+  }
+  /// Set the particle ID.
+  /// @param idx Original particle index (to match HepMC file)
+  /// @return Reference to this particle in HepMC file
+  Particle &setOrigParticleIdx(std::uint32_t idx) {
+    m_origParticleIdx = idx;
     return *this;
   }
   /// Set the space-time position four-vector.
@@ -175,33 +179,22 @@ class Particle {
   /// Set the absolute momentum.
   /// @param absMomentum Absolute momentum magnitude
   /// @return Reference to this particle for method chaining
-  /// @throws std::invalid_argument if absMomentum is negative
   Particle &setAbsoluteMomentum(double absMomentum) {
-    if (absMomentum < 0) {
-      throw std::invalid_argument("Absolute momentum cannot be negative.");
-    }
     m_absMomentum = absMomentum;
     return *this;
   }
 
-  /// Reduce the energy by the given amount. If the energy loss exceeds the
-  /// current energy, the particle is killed with the specified outcome. If
-  /// stopping the particle was not expected (stoppedOutcome is Alive), an
-  /// exception is thrown.
-  /// @param delta The energy loss amount to subtract from the current energy
-  /// @param stoppedOutcome The outcome to set if the energy loss exceeds the current energy
+  /// Change the energy by the given amount.
+  ///
+  /// Energy loss corresponds to a negative change. If the updated energy
+  /// would result in an unphysical value, the particle is put to rest, i.e.
+  /// its absolute momentum is set to zero.
+  /// @param delta Energy change (negative for energy loss)
   /// @return Reference to this particle for method chaining
-  /// @throws std::invalid_argument if the energy loss exceeds the current energy and stoppedOutcome is Alive
-  Particle &loseEnergy(double delta, SimulationOutcome stoppedOutcome =
-                                         SimulationOutcome::Alive) {
-    const double newEnergy = energy() - delta;
+  Particle &correctEnergy(double delta) {
+    const auto newEnergy = std::hypot(m_mass, m_absMomentum) + delta;
     if (newEnergy <= m_mass) {
-      if (stoppedOutcome == SimulationOutcome::Alive) {
-        throw std::invalid_argument(
-            "Energy loss cannot exceed the current energy of the particle if "
-            "the particle is to remain alive.");
-      }
-      killParticle(stoppedOutcome);
+      m_absMomentum = 0.;
     } else {
       m_absMomentum = Acts::fastCathetus(newEnergy, m_mass);
     }
@@ -211,9 +204,15 @@ class Particle {
   /// Particle identifier within an event.
   /// @return The unique particle identifier barcode
   Barcode particleId() const { return m_particleId; }
+  /// Original particle index (to match HepMC) 
+  /// @return The particle index
+  std::uint32_t origParticleIdx() const { return m_origParticleIdx; }
+  /// Particle HF origin (0->none, 4->charm, 5->beauty) 
+  /// @return The particle index
+  Acts::HfOrigin hfOrigin() const { return m_hfOrigin; }
   /// Which type of process generated this particle.
   /// @return The process type that generated this particle
-  GenerationProcess process() const { return m_process; }
+  ProcessType process() const { return m_process; }
   /// PDG particle number that identifies the type.
   /// @return The PDG particle identifier
   Acts::PdgParticle pdg() const { return m_pdg; }
@@ -237,7 +236,7 @@ class Particle {
   Acts::ParticleHypothesis hypothesis() const {
     return Acts::ParticleHypothesis(
         absolutePdg(), static_cast<float>(mass()),
-        Acts::ChargeHypothesis{static_cast<float>(absoluteCharge())});
+        Acts::AnyCharge{static_cast<float>(absoluteCharge())});
   }
   /// Particl qOverP.
   /// @return The charge over momentum ratio
@@ -291,7 +290,7 @@ class Particle {
 
   /// Check if the particle is alive, i.e. is not at rest.
   /// @return True if particle has non-zero momentum, false otherwise
-  bool isAlive() const { return m_outcome == SimulationOutcome::Alive; }
+  bool isAlive() const { return 0. < m_absMomentum; }
 
   /// Check if this is a secondary particle.
   /// @return True if particle is a secondary (has non-zero vertex secondary, generation, or sub-particle), false otherwise
@@ -391,41 +390,45 @@ class Particle {
   ///
   /// @param outcome outcome code
   /// @return Reference to this particle for method chaining
-  Particle &setOutcome(SimulationOutcome outcome) {
+  Particle &setOutcome(ParticleOutcome outcome) {
     m_outcome = outcome;
     return *this;
   }
 
   /// Particle outcome.
   /// @return The outcome status of this particle
-  SimulationOutcome outcome() const { return m_outcome; }
+  ParticleOutcome outcome() const { return m_outcome; }
 
  private:
   // identity, i.e. things that do not change over the particle lifetime.
   /// Particle identifier within the event.
   Barcode m_particleId;
   /// Process type specifier.
-  GenerationProcess m_process = GenerationProcess::eUndefined;
+  ProcessType m_process = ProcessType::eUndefined;
   /// PDG particle number.
   Acts::PdgParticle m_pdg = Acts::PdgParticle::eInvalid;
   // Particle charge and mass.
-  double m_charge = 0;
-  double m_mass = 0;
+  double m_charge = 0.;
+  double m_mass = 0.;
   // kinematics, i.e. things that change over the particle lifetime.
   Acts::Vector3 m_direction = Acts::Vector3::UnitZ();
-  double m_absMomentum = 0;
+  double m_absMomentum = 0.;
   Acts::Vector4 m_position4 = Acts::Vector4::Zero();
   /// proper time in the particle rest frame
-  double m_properTime = 0;
+  double m_properTime = 0.;
   // accumulated material
-  double m_pathInX0 = 0;
-  double m_pathInL0 = 0;
+  double m_pathInX0 = 0.;
+  double m_pathInL0 = 0.;
   /// number of hits
   std::uint32_t m_numberOfHits = 0;
+  /// particle index to match the HepMC file
+  std::uint32_t m_origParticleIdx = 0;
+  /// particle origin (0->LF, 4->charm, 5->beauty)
+  Acts::HfOrigin m_hfOrigin = Acts::HfOrigin::None;
   /// reference surface
   const Acts::Surface *m_referenceSurface{nullptr};
   /// outcome
-  SimulationOutcome m_outcome = SimulationOutcome::Alive;
+  ParticleOutcome m_outcome = ParticleOutcome::Alive;
 };
 
 /// Print particle to output stream

--- a/Fatras/include/ActsFatras/EventData/Particle.hpp
+++ b/Fatras/include/ActsFatras/EventData/Particle.hpp
@@ -123,6 +123,20 @@ class Particle {
     m_particleId = barcode;
     return *this;
   }
+  /// Set the particle HF origin (0->none, 4->charm, 5->beauty) 
+  /// @param orig particle HF origin (0->none, 4->charm, 5->beauty) 
+  /// @return Reference to this particle in HepMC file
+  Particle &setHfOrigin(Acts::HfOrigin orig) {
+    m_hfOrigin = orig;
+    return *this;
+  }
+  /// Set the particle ID.
+  /// @param idx Original particle index (to match HepMC file)
+  /// @return Reference to this particle in HepMC file
+  Particle &setOrigParticleIdx(std::uint32_t idx) {
+    m_origParticleIdx = idx;
+    return *this;
+  }
   /// Set the space-time position four-vector.
   /// @param pos4 Four-vector containing spatial position and time
   /// @return Reference to this particle for method chaining

--- a/Python/Examples/python/simulation.py
+++ b/Python/Examples/python/simulation.py
@@ -14,6 +14,7 @@ from acts.examples import (
     CsvVertexWriter,
 )
 import acts.examples.hepmc3
+import acts.examples.geant4
 
 # ROOT might not be available
 try:
@@ -207,7 +208,7 @@ def addParticleGun(
         inputEvent=evGen.config.outputEvent,
         outputParticles="particles_generated",
         outputVertices="vertices_generated",
-        mergePrimaries=False,
+        mergePrimaries=False
     )
     s.addAlgorithm(hepmc3Converter)
 
@@ -286,6 +287,7 @@ def addPythia8(
     writeHepMC3: Optional[Path] = None,
     printListing: bool = False,
     logLevel: Optional[acts.logging.Level] = None,
+    searchUpToHfQuark: bool = False
 ) -> None:
     """This function steers the particle generation using Pythia8
 
@@ -315,6 +317,8 @@ def addPythia8(
         write directly from Pythia8 into HepMC3
     printPythiaEventListing
         None or "short" or "long"
+    searchUpToHfQuark: bool
+        Search up to the quark in HF tagging        
     """
 
     import acts
@@ -398,6 +402,7 @@ def addPythia8(
         outputParticles="particles_generated",
         outputVertices="vertices_generated",
         printListing=printListing,
+        searchUpToHfQuark=searchUpToHfQuark
     )
     s.addAlgorithm(hepmc3Converter)
     s.addWhiteboardAlias("particles", hepmc3Converter.config.outputParticles)

--- a/Python/Examples/python/simulation.py
+++ b/Python/Examples/python/simulation.py
@@ -14,7 +14,6 @@ from acts.examples import (
     CsvVertexWriter,
 )
 import acts.examples.hepmc3
-import acts.examples.geant4
 
 # ROOT might not be available
 try:

--- a/Python/Examples/src/plugins/HepMC3.cpp
+++ b/Python/Examples/src/plugins/HepMC3.cpp
@@ -93,7 +93,7 @@ PYBIND11_MODULE(ActsExamplesPythonBindingsHepMC3, hepmc3) {
       HepMC3InputConverter, hepmc3, "HepMC3InputConverter", inputEvent,
       outputParticles, outputVertices, printListing, checkConsistency,
       mergePrimaries, primaryVertexSpatialThreshold, vertexSpatialThreshold,
-      mergeSecondaries);
+      mergeSecondaries, searchUpToHfQuark);
 
   {
     using enum HepMC3Util::Compression;


### PR DESCRIPTION
As discussed offline @njacazio this PR adds minimal MC truth information to trace back tracks produced by HF hadrons/quarks. In particular, it adds in the root outputs:
- A branch containing the information whether the track comes from charm/beauty (by default hadrons, with the possibility to search in the kine tree up to the quarks)
- A branch containing the information of the HepMC3 particle index to map it to the HepMC3 output that contains the full information

Tagging also @atriolo and @apalasciano